### PR TITLE
Localization file name correction

### DIFF
--- a/mod_tasklist/language/en-GB/mod_tasklist.sys.ini
+++ b/mod_tasklist/language/en-GB/mod_tasklist.sys.ini
@@ -1,0 +1,6 @@
+; (C) 2022 Brian Teeman
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+MOD_TASKLIST="Task List"
+MOD_TASKLIST_XML_DESCRIPTION="This module allows you to add tasks and mark them as complete. They are stored in your web browser and cannot be accessed by anyone else. This module is intended to be published in the 'status' position with access set to 'special'.

--- a/mod_tasklist/language/en-GB/mod_tasklist_sys.ini
+++ b/mod_tasklist/language/en-GB/mod_tasklist_sys.ini
@@ -1,6 +1,0 @@
-; (C) 2022 Brian Teeman
-; License GNU General Public License version 2 or later; see LICENSE.txt
-; Note : All ini files need to be saved as UTF-8
-
-MOD_TASKLIST="Task List"
-MOD_TASKLIST_XML_DESCRIPTION="This module allows you to add tasks and mark them as complete. They are stored in your web browser and cannot be accessed by anyone else. This module is intended to be published in the 'status' position with access set to 'special'.


### PR DESCRIPTION
During installation, the title and description are not defined due to an invalid localization file name.